### PR TITLE
add apps.${system}.vm to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,16 @@
         inherit pkgs;
       };
     };
+    apps.${system} = {
+      # Run the VM with `nixos run .#vm`
+      vm = {
+        type = "app";
+        program =
+          let
+            config = self.nixosConfigurations.vm.config;
+          in "${config.system.build.vm}/bin/run-${config.networking.hostName}-vm";
+      };
+    };
 
     checks.${system} = {
       format =


### PR DESCRIPTION
convenience so that testers don't need to enter a devshell with nixos-shell to start a vm. just `nix run .#vm`