### PR TITLE
debugEnabled is a dependency of debugPrint

### DIFF
--- a/frontend/search/components/ngo/DeclarativeDataGrid.tsx
+++ b/frontend/search/components/ngo/DeclarativeDataGrid.tsx
@@ -163,7 +163,7 @@ const DeclarativeDataGrid = <T, >({
 
   const debugPrint = useCallback((selectedId) => {
     debugEnabled && console.log({selectedData: data.filter(d => (d as any).id === selectedId)})
-  }, [data])
+  }, [data, debugEnabled])
 
   useEffect(() => {
     selectedId && scrollTo(selectedId)

--- a/frontend/search/components/ngo/DeclarativeDataGrid.tsx
+++ b/frontend/search/components/ngo/DeclarativeDataGrid.tsx
@@ -167,8 +167,11 @@ const DeclarativeDataGrid = <T, >({
 
   useEffect(() => {
     selectedId && scrollTo(selectedId)
+  }, [selectedId, scrollTo])
+
+  useEffect(() => {
     selectedId && debugPrint(selectedId)
-  }, [selectedId, scrollTo, debugPrint]);
+  }, [selectedId, debugPrint])
 
   const handleRowSelect = useCallback(({selected}: TypeOnSelectionChangeArg) => {
     typeof selected === 'string' && onRowSelect && onRowSelect(selected)


### PR DESCRIPTION
```typescript
const debugPrint = useCallback((selectedId) => {
    debugEnabled && console.log({selectedData: data.filter(d => (d as any).id === selectedId)})
  }, [data, debugEnabled])

  useEffect(() => {
    selectedId && debugPrint(selectedId)
  }, [selectedId, debugPrint])
```

this means `useEffect` depends on `selectedId` and `data` and `debugEnabled`, because it depends on `debugPrint`, thus it is beeing called if `data`, `selectedId` or `enableDebug` changes (the callback will not change, even  if they could in theory`

now, if you include the `scrollTo` call in the `useEffect`, it will scoll to `selectedId` not only if the `selectedId` changes, but also if `data` or `enableDebug` changes. This is something we do not want, as it leads to scrolling in cases the user does not expect it
